### PR TITLE
Left-click in test table to reset ball

### DIFF
--- a/src/scenes/test_table.gd
+++ b/src/scenes/test_table.gd
@@ -1,0 +1,13 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	if Input.is_mouse_button_pressed(MouseButton.MOUSE_BUTTON_LEFT):
+		$pinball.translate(get_global_mouse_position() - $pinball.global_position)
+		$pinball.linear_velocity = Vector2.ZERO

--- a/src/scenes/test_table.gd.uid
+++ b/src/scenes/test_table.gd.uid
@@ -1,0 +1,1 @@
+uid://vfe4wa6j1dex

--- a/src/scenes/test_table.tscn
+++ b/src/scenes/test_table.tscn
@@ -1,16 +1,19 @@
 [gd_scene format=3 uid="uid://c6bjuucykdcgk"]
 
 [ext_resource type="PackedScene" uid="uid://bkqm7am1p7jmt" path="res://scenes/flipper.tscn" id="1_ar12w"]
+[ext_resource type="Script" uid="uid://vfe4wa6j1dex" path="res://scenes/test_table.gd" id="1_wwlei"]
 [ext_resource type="PackedScene" uid="uid://c6vfjvuytl240" path="res://scenes/pinball.tscn" id="2_wwlei"]
 
 [node name="test_table" type="Node2D" unique_id=219498551]
+script = ExtResource("1_wwlei")
 
 [node name="Flipper" parent="." unique_id=1506876985 instance=ExtResource("1_ar12w")]
-position = Vector2(-16, 96)
+position = Vector2(359, 452)
 
 [node name="Flipper2" parent="." unique_id=1533600956 instance=ExtResource("1_ar12w")]
-position = Vector2(432, 96)
+position = Vector2(830, 454)
 scale = Vector2(-1, 1)
 flipper_direction = 1
 
 [node name="pinball" parent="." unique_id=782531317 instance=ExtResource("2_wwlei")]
+position = Vector2(744, 308)


### PR DESCRIPTION
When running the test table scene, you can left-click within the scene to make the ball move to the cursor. This will also reset its linear velocity. This should be handy when testing out trying to hit things with the ball in the test scene.