### PR TITLE
Update rebound nocollide logic to ignore flippers and scoring actions

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -72,6 +72,7 @@ damage_kicker=""
 2d_physics/layer_4="OneWayPlatforms"
 2d_physics/layer_5="roundBumper"
 2d_physics/layer_6="walls"
+2d_physics/layer_7="flippers"
 
 [physics]
 

--- a/src/scenes/flipper.tscn
+++ b/src/scenes/flipper.tscn
@@ -9,6 +9,7 @@
 script = ExtResource("1_cdoxy")
 
 [node name="AnimatableBody2D" type="AnimatableBody2D" parent="." unique_id=1926957834]
+collision_layer = 64
 sync_to_physics = false
 metadata/_edit_lock_ = true
 

--- a/src/scenes/pinball.tscn
+++ b/src/scenes/pinball.tscn
@@ -12,7 +12,7 @@ loop_end = 74926
 stereo = true
 
 [node name="pinball" type="RigidBody2D" unique_id=782531317 groups=["pinballs"]]
-collision_mask = 55
+collision_mask = 119
 contact_monitor = true
 max_contacts_reported = 5
 script = ExtResource("1_5eq27")

--- a/src/scripts/pinball.gd
+++ b/src/scripts/pinball.gd
@@ -3,7 +3,7 @@ class_name Pinball extends RigidBody2D
 signal ball_hit_something(hit_object: Node)
 signal egg_is_broken
 
-const rebound_nocollide_layers := [2, 3, 4, 5, 6]
+const rebound_nocollide_layers := [2, 3, 4, 5, 6, 7]
 const default_sprite_scale := Vector2(0.25, 0.25)
 
 var old_velocity: Vector2
@@ -51,7 +51,7 @@ func _physics_process(_delta: float) -> void:
 		end_rebound()
    
 func _on_body_entered(body: Node) -> void:
-	if(body.is_in_group("hittable_object")):
+	if(body.is_in_group("hittable_object")) and rebounding == false:
 		emit_signal("ball_hit_something", body)
 		if(body.is_in_group("round_bumper")): # rbumper revision
 			var kickaim: Vector2 = body.aim(self.global_position) # rbumper revision end


### PR DESCRIPTION
Moves flippers onto their own collision layer, remasks the ball to continue interacting with them, and adds that layer to the layers that Rebound ignores until the ball "drops back in" to the board. Also disables scoring-style impacts during Rebound, preventing scoring objects from blocking the ball from returning to play.