### PR TITLE
Add fade out/fade in between scenes

### DIFF
--- a/src/scenes/conductor.tscn
+++ b/src/scenes/conductor.tscn
@@ -35,3 +35,11 @@ grow_horizontal = 2
 grow_vertical = 2
 texture = ExtResource("3_q7w51")
 expand_mode = 3
+
+[node name="FadeZone" type="ColorRect" parent="." unique_id=803434350]
+z_index = 2
+offset_left = 30.0
+offset_top = 130.0
+offset_right = 510.0
+offset_bottom = 930.0
+color = Color(0, 0, 0, 0)

--- a/src/scripts/conductor.gd
+++ b/src/scripts/conductor.gd
@@ -54,7 +54,13 @@ func switch_scene(scene: PackedScene):
 	current_scene.disconnect("update_message", _on_update_message)
 	new_scene.connect("go_to_scene", _on_go_to_scene)
 	new_scene.connect("update_message", _on_update_message)
+	
+	var fadeOutTween = get_tree().create_tween()
+	fadeOutTween.tween_property($FadeZone, "color",Color(0.0, 0.0, 0.0, 1.0), 1.0)
+	await fadeOutTween.finished
 	$TableContainer.remove_child(current_scene)
 	$TableContainer.add_child(new_scene)
 	current_scene.queue_free()
 	current_scene = new_scene
+	var fadeInTween = get_tree().create_tween()
+	fadeInTween.tween_property($FadeZone, "color",Color(0.0, 0.0, 0.0, 0.0), 1.0)

--- a/src/scripts/pinball.gd
+++ b/src/scripts/pinball.gd
@@ -18,11 +18,13 @@ var rebounding = false;
 
 @export var starting_health = 12
 var health = starting_health
+var spriteHealthChange: float
 
 var rng = RandomNumberGenerator.new()
 
 func _ready() -> void:
 	$RollSound.play()
+	spriteHealthChange = starting_health / float($Sprite2D.hframes * $Sprite2D.vframes)
 
 func _exit_tree() -> void:
 	$RollSound.stop()
@@ -63,7 +65,7 @@ func _on_body_entered(body: Node) -> void:
 		health -= 1
 		if health > 0:
 			play_egg_crack_sound()
-			$Sprite2D.frame = int((starting_health - health) / 3)
+			$Sprite2D.frame = floor((starting_health - health) / spriteHealthChange)
 		else:
 			play_egg_break_sound()
 			$Sprite2D.visible = false


### PR DESCRIPTION
When changing scenes, fade a black rectangle in over the TableContainer, then switch scenes, then fade that rectangle out. Each fade operation lasts 1 second.

Fix minor bug in pinball sprite frame calculation. New calculation is based on starting health, which means that the math should work okay even if the starting health is changed.