### PR TITLE
Do not let pinball fall asleep

### DIFF
--- a/src/scenes/pinball.tscn
+++ b/src/scenes/pinball.tscn
@@ -24,6 +24,7 @@ stereo = true
 
 [node name="pinball" type="RigidBody2D" unique_id=782531317 groups=["pinballs"]]
 collision_mask = 247
+can_sleep = false
 contact_monitor = true
 max_contacts_reported = 5
 script = ExtResource("1_5eq27")


### PR DESCRIPTION
Fixes #48 

A RigidBody2D can fall asleep, which is why the egg would get stuck sometimes if held with the flipper for a few seconds. By not letting the egg fall asleep, it won't get stuck.