### PR TITLE
Add small animation tweens for egg, bumpers, targets

### DIFF
--- a/src/scripts/drop_target.gd
+++ b/src/scripts/drop_target.gd
@@ -7,7 +7,6 @@ signal target_dropped
 @export var value := 15
 
 var _down := false
-var animation_duration = 0.2
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -33,15 +32,17 @@ func drop() -> void:
 	$DropSound.play()
 	_down = true
 	var dropTween = get_tree().create_tween()
-	dropTween.set_trans(Tween.TRANS_LINEAR)
-	dropTween.tween_property($Sprites, "scale", Vector2(1.0, 0.0), animation_duration)
+	dropTween.set_trans(Tween.TRANS_BACK)
+	dropTween.set_ease(Tween.EASE_IN)
+	dropTween.tween_property($Sprites, "scale", Vector2(0.0, 0.0), 0.08)
 
 func raise() -> void:
 	$CollisionShape2D.set_deferred("disabled", false)
 	_down = false
 	var raiseTween = get_tree().create_tween()
-	raiseTween.set_trans(Tween.TRANS_LINEAR)
-	raiseTween.tween_property($Sprites, "scale", Vector2(1.0, 1.0), animation_duration)
+	raiseTween.set_trans(Tween.TRANS_SPRING)
+	raiseTween.set_ease(Tween.EASE_OUT)
+	raiseTween.tween_property($Sprites, "scale", Vector2(1.0, 1.0), 0.2)
 	
 # Returns true if target has been dropped.
 func is_down() -> bool:

--- a/src/scripts/drop_target.gd
+++ b/src/scripts/drop_target.gd
@@ -7,6 +7,7 @@ signal target_dropped
 @export var value := 15
 
 var _down := false
+var animation_duration = 0.2
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -27,16 +28,20 @@ func receive_hit(_speed: Vector2) -> int: #-> void: # revision 1
 	return value # revision 1
 
 func drop() -> void:
-	$Sprites.set_deferred("visible", false)
 	$CollisionShape2D.set_deferred("disabled", true)
 	$HitSound.play()
 	$DropSound.play()
 	_down = true
+	var dropTween = get_tree().create_tween()
+	dropTween.set_trans(Tween.TRANS_LINEAR)
+	dropTween.tween_property($Sprites, "scale", Vector2(1.0, 0.0), animation_duration)
 
 func raise() -> void:
-	$Sprites.set_deferred("visible", true)
 	$CollisionShape2D.set_deferred("disabled", false)
 	_down = false
+	var raiseTween = get_tree().create_tween()
+	raiseTween.set_trans(Tween.TRANS_LINEAR)
+	raiseTween.tween_property($Sprites, "scale", Vector2(1.0, 1.0), animation_duration)
 	
 # Returns true if target has been dropped.
 func is_down() -> bool:

--- a/src/scripts/pinball.gd
+++ b/src/scripts/pinball.gd
@@ -5,6 +5,7 @@ signal egg_is_broken
 
 const rebound_nocollide_layers := [2, 3, 4, 5, 6, 7]
 const default_sprite_scale := Vector2(0.25, 0.25)
+const rebounding_sprite_scale = Vector2(0.33, 0.33)
 
 var old_velocity: Vector2
 var min_velocity_for_thunk = 200000.0
@@ -87,7 +88,10 @@ func rebound() -> void:
 	can_end_rebound = false
 	set_linear_velocity(Vector2(rng.randf_range(-750.0, 750.0), -1500))
 	set_rebound_nocollide(true)
-	$Sprite2D.scale = Vector2(0.3, 0.3)
+	var reboundScaleTween = get_tree().create_tween()
+	reboundScaleTween.set_trans(Tween.TRANS_QUAD)
+	reboundScaleTween.tween_property($Sprite2D, "scale", rebounding_sprite_scale, 0.5)
+	reboundScaleTween.tween_property($Sprite2D, "scale", default_sprite_scale, 0.5)
 	
 	await get_tree().create_timer(1.0).timeout
 	can_end_rebound = true

--- a/src/scripts/pinball.gd
+++ b/src/scripts/pinball.gd
@@ -5,7 +5,7 @@ signal egg_is_broken
 
 const rebound_nocollide_layers := [2, 3, 4, 5, 6, 7]
 const default_sprite_scale := Vector2(0.25, 0.25)
-const rebounding_sprite_scale = Vector2(0.33, 0.33)
+const rebounding_sprite_scale = Vector2(0.40, 0.40)
 
 var old_velocity: Vector2
 var min_velocity_for_thunk = 200000.0
@@ -90,7 +90,9 @@ func rebound() -> void:
 	set_rebound_nocollide(true)
 	var reboundScaleTween = get_tree().create_tween()
 	reboundScaleTween.set_trans(Tween.TRANS_QUAD)
+	reboundScaleTween.set_ease(Tween.EASE_OUT)
 	reboundScaleTween.tween_property($Sprite2D, "scale", rebounding_sprite_scale, 0.5)
+	reboundScaleTween.set_ease(Tween.EASE_IN)
 	reboundScaleTween.tween_property($Sprite2D, "scale", default_sprite_scale, 0.5)
 	
 	await get_tree().create_timer(1.0).timeout

--- a/src/scripts/round_bumper.gd
+++ b/src/scripts/round_bumper.gd
@@ -11,14 +11,16 @@ var bumpty_scale = Vector2(0.06, 0.06)
 
 func _ready():
 	stable_scale = $Sprite2D.scale
-
+  
 # receive_hit is called by the table any time the ball strikes something to handle scoring and table-wide mechanics
 func receive_hit(_speed: Vector2) -> int:
 	$HitSound.play()
 	var bumpingTween = get_tree().create_tween()
-	bumpingTween.set_trans(Tween.TRANS_LINEAR)
-	bumpingTween.tween_property($Sprite2D, "scale", stable_scale + bumpty_scale, 0.1)
-	bumpingTween.tween_property($Sprite2D, "scale", stable_scale, 0.1)
+	bumpingTween.set_ease(Tween.EASE_OUT) 
+	bumpingTween.set_trans(Tween.TRANS_CUBIC)
+	bumpingTween.tween_property($Sprite2D, "scale", stable_scale + bumpty_scale, 0.04)
+	bumpingTween.set_trans(Tween.TRANS_SPRING)
+	bumpingTween.tween_property($Sprite2D, "scale", stable_scale, 0.15)
 	return value
 
 func aim(ballpos: Vector2) -> Vector2:

--- a/src/scripts/round_bumper.gd
+++ b/src/scripts/round_bumper.gd
@@ -6,9 +6,19 @@ var value: int = 10
 #how hard the bumper kicks the ball on contact. unlike flat bumpers, this shouldn't be affected as strongly by the bumper's scale
 var kick_strength: int = 20
 
+var stable_scale: Vector2
+var bumpty_scale = Vector2(0.06, 0.06)
+
+func _ready():
+	stable_scale = $Sprite2D.scale
+
 # receive_hit is called by the table any time the ball strikes something to handle scoring and table-wide mechanics
 func receive_hit(_speed: Vector2) -> int:
 	$HitSound.play()
+	var bumpingTween = get_tree().create_tween()
+	bumpingTween.set_trans(Tween.TRANS_LINEAR)
+	bumpingTween.tween_property($Sprite2D, "scale", stable_scale + bumpty_scale, 0.1)
+	bumpingTween.tween_property($Sprite2D, "scale", stable_scale, 0.1)
 	return value
 
 func aim(ballpos: Vector2) -> Vector2:


### PR DESCRIPTION
When the egg is launched off the damage kicker, scale up and then back down for the duration of the launch state.
When the egg hits a round bumper, do a quick scale up on the bumper. When the egg hits a target and causes it to drop, scale the target's height to 0%.
When a target in a group gets reset and raised, scale the target's height back to 100%.

Addresses #42