### PR TITLE
Spinner adjustments

### DIFF
--- a/src/scripts/spinner_area2d.gd
+++ b/src/scripts/spinner_area2d.gd
@@ -1,7 +1,7 @@
 class_name Spinner extends Area2D
 
 ## point value per spin
-@export var value: int
+@export var value := 10
 
 signal generate_points(points: int)
 
@@ -10,14 +10,14 @@ var address
 ## How fast the spinner is spinning around its axis.
 var speed := 0.0
 ## Rate of spin speed decay per second.
-var _speed_decay := 4.0
+const _speed_decay := 4.0
 ## The rotation position the spinner "seeks" to rest at.
-var _resting_axis_rotation := PI / 2
+const _resting_axis_rotation := PI / 2
 ## How slow the spinner has to be moving to stop, and the minimum speed until it
 ## reaches rest position.
-var _rest_speed_threshold := 3.0;
+const _rest_speed_threshold := 5;
 ## How close the rotation has to be to resting position to stop.
-var _rest_rotation_threshold := PI / 64
+const _rest_rotation_threshold := PI / 64
 
 var _axis_rotation := _resting_axis_rotation 
 
@@ -39,7 +39,7 @@ func _process(delta: float) -> void:
 
 	# if we were previously less than the rest point, and are now >= rest point, we completed a spin
 	# when we complete a spin, emit Points
-	var old_rotation = fmod(_axis_rotation, 2 * PI)
+	var old_rotation = fmod(_axis_rotation, PI)
 	var rotation_amount = speed * delta
 	_axis_rotation += rotation_amount
 	if rotation_amount > 0.0 and \
@@ -51,7 +51,7 @@ func _process(delta: float) -> void:
 		$spinnerflick.play()
 
 	# Simulate vertical spinning with scaling.
-	$RotatingItems.set_scale(Vector2(1, sin(_axis_rotation)))
+	$RotatingItems.set_scale(Vector2(1, abs(sin(_axis_rotation))))
 	
 
 # rigidbodys like the ball can't detect entering areas, so this prompts the ball to
@@ -61,6 +61,6 @@ func _on_body_entered(body: Node2D) -> void:
 
 # scoring logic
 func receive_hit(velocity: Vector2) -> int:
-	speed = velocity.length() / 20
+	speed = velocity.length() / 40
 	print("speed: " + str(speed) + " mph")
 	return 0


### PR DESCRIPTION
Spinners:

- Score points and make sound on every half-spin instead of full spin.
- Always have a positive y-scale when "rotating" (to reflect the slight perspective on sprite).
- Spin slower.
- Have a higher minimum rotation speed.